### PR TITLE
Added KConfigCore module

### DIFF
--- a/Babe.pro
+++ b/Babe.pro
@@ -19,6 +19,7 @@ QT       += sql
 QT       += network
 QT       += xml
 QT       += dbus
+QT       += KConfigCore
 QT       += KNotifications
 QT       += KI18n
 

--- a/collectionDB.cpp
+++ b/collectionDB.cpp
@@ -167,7 +167,7 @@ bool CollectionDB::checkQuery(QString queryTxt)
             return true;
         }else
         {
-            qDebug()<<"didn't ind the query!";
+            qDebug()<<"didn't find the query!";
             return false;
         }
     }else


### PR DESCRIPTION
KNotification requires headers provided by KconfigCore. Without this line it won't build.